### PR TITLE
adding sockets for youtube load/play/pause

### DIFF
--- a/private/socket-api.js
+++ b/private/socket-api.js
@@ -27,6 +27,10 @@ module.exports = (socket, io) => {
     socket.broadcast.emit('receiveWhiteboardMouse', data)
   })
 
+  socket.on('broadcastYTUpdate', (data) => {
+    socket.broadcast.emit('receiveYTUpdate', data)
+  })
+
   socket.on('disconnect', () => {
     userToSocketId.delete(socket.userId)
     socket.broadcast.emit('receiveDisconnectedWhiteboardUserId', { id: socket.userId })

--- a/public/whiteboard/js/YTsampler.js
+++ b/public/whiteboard/js/YTsampler.js
@@ -25,6 +25,7 @@ class YTSampler extends window.HTMLElement {
     const btn = this.querySelector('button')
     const url = this.querySelector('input')
     btn.addEventListener('click', () => {
+      this._emit('videoLoaded', url.value)
       this.loadVideo(url.value)
     })
   }
@@ -47,14 +48,19 @@ class YTSampler extends window.HTMLElement {
     btn.textContent = 'play'
     btn.addEventListener('click', () => {
       if (btn.textContent === 'play') {
+        this._emit('videoPlayed')
         this.play()
-        btn.textContent = 'pause'
       } else {
+        this._emit('videoPaused')
         this.pause()
-        btn.textContent = 'play'
       }
     })
     sec.appendChild(btn)
+  }
+
+  _changeToggle (text) {
+    const toggle = this.querySelector('.yt-toggle-button')
+    toggle.textContent = text
   }
 
   _playerLoaded (e) {
@@ -94,6 +100,12 @@ class YTSampler extends window.HTMLElement {
     return videoId
   }
 
+  _emit (name, data) {
+    const eveObj = { detail: data }
+    const eve = new window.CustomEvent(name, eveObj)
+    this.dispatchEvent(eve)
+  }
+
   loadVideo (url) {
     if (url === '') return window.alert('missing Youtube Url')
     const vidId = this._idFromUrl(url)
@@ -108,10 +120,12 @@ class YTSampler extends window.HTMLElement {
 
   play () {
     this.player.playVideo()
+    this._changeToggle('pause')
   }
 
   pause () {
     this.player.pauseVideo()
+    this._changeToggle('play')
   }
 
   stop () {

--- a/public/whiteboard/js/main.js
+++ b/public/whiteboard/js/main.js
@@ -77,6 +77,24 @@ window.p5Obj = new p5((p) => {
     youTube.position(0, de.scrollTop)
     youTube.id('youTubeSampler')
     youTube.parent('tools')
+
+    youTube.elt.addEventListener('videoLoaded', (e) => {
+      socket.emit('broadcastYTUpdate', { type: 'load', url: e.detail })
+    })
+
+    youTube.elt.addEventListener('videoPlayed', () => {
+      socket.emit('broadcastYTUpdate', { type: 'play' })
+    })
+
+    youTube.elt.addEventListener('videoPaused', () => {
+      socket.emit('broadcastYTUpdate', { type: 'pause' })
+    })
+
+    socket.on('receiveYTUpdate', (data) => {
+      if (data.type === 'play') youTube.elt.play()
+      else if (data.type === 'pause') youTube.elt.pause()
+      else if (data.type === 'load') youTube.elt.loadVideo(data.url)
+    })
   }
 
   p.draw = () => {


### PR DESCRIPTION
We get this error sometimes: [stack overflow](https://stackoverflow.com/questions/27573017/failed-to-execute-postmessage-on-domwindow-https-www-youtube-com-http)

Presumably it is best fixed when we are deploying the website on a server rather than hardcoding a localhost:8000?